### PR TITLE
Call docker-compose from pull script

### DIFF
--- a/production/pull-docker-hub.sh
+++ b/production/pull-docker-hub.sh
@@ -6,4 +6,5 @@ cd /home/ubuntu/repos/matprat-website ; git pull
 
 # Pull the latest image from docker hub
 echo '\nPull the latest image from Docker Hub...'
-cd /home/ubuntu/repos/matprat-website/production ; ./start-system.sh
+cd /home/ubuntu/repos/matprat-website/production ; \
+docker-compose -f docker-compose.yml -f webhooks/docker-compose.yml up --remove-orphan -d


### PR DESCRIPTION
Instead of calling the start-system.sh script that includes starting the webhook, now docker-compose is directly invoked.

The problem was that webhook was trying to run start-system.sh that also starts webhook itself.