### PR TITLE
Include `latest` Tag in Docker Hub

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,4 +33,6 @@ jobs:
           context: server/
           platforms: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/pratmat:alpha-latest
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/pratmat:alpha-latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/pratmat:latest


### PR DESCRIPTION
Adds a `latest` tag additional to `alpha-latest`. This ensure the image can be pulled down doing `docker pull mariugul/pratmat`