### PR TITLE
feat: add GitHub Actions workflow for versioned Docker deployments

### DIFF
--- a/.github/workflows/deploy-version.yml
+++ b/.github/workflows/deploy-version.yml
@@ -1,0 +1,41 @@
+name: Deploy Version
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'  # Triggers on tags like v1.0.0, v2.1.3, etc.
+
+jobs:
+  deploy-version:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Extract version from tag
+        id: get_version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          image: tonistiigi/binfmt:qemu-v6.1.0
+          platforms: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: server/
+          platforms: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/pratmat:${{ steps.get_version.outputs.VERSION }}


### PR DESCRIPTION
- Add deploy-version.yml workflow triggered on version tags (v*.*.*)
- Extract version from git tag and use as Docker image tag
- Configure multi-platform Docker build (amd64, arm/v6, arm/v7, arm64/v8, ppc64le, s390x)
- Set up QEMU and Docker Buildx for cross-platform builds
- Push versioned images to DockerHub on tag creation