### PR TITLE
fix: redirect interactive prompts to /dev/tty in install.sh

### DIFF
--- a/database/init_database.sh
+++ b/database/init_database.sh
@@ -1,20 +1,85 @@
 #!/bin/sh
 #
-# This script initializes the "matprat" database and the "nodejs" role.
-# First the role and database is created and then the data that exists
-# in the sql-files are inserted into the database.
+# This script initializes the database with schema and optionally sample data.
+# Can be configured via environment variables or command line arguments.
+#
+# Usage:
+#   ./init_database.sh [options]
+#
+# Environment variables (or use flags):
+#   DB_HOST     - Database host (default: localhost)
+#   DB_PORT     - Database port (default: 5432)
+#   DB_NAME     - Database name (default: matprat)
+#   DB_USER     - Database user (default: nodejs)
+#   DB_PASSWORD - Database password (default: nodejs)
+#   SQL_PATH    - Path to SQL files (default: ./sql)
+#
+# Options:
+#   -h, --host      Database host
+#   -p, --port      Database port
+#   -d, --database  Database name
+#   -u, --user      Database user
+#   -w, --password  Database password
+#   -s, --sql-path  Path to SQL files
+#   --with-data     Also insert sample recipe data
+#   --help          Show this help message
 
-path="/workspace/database/sql"
+set -e
 
-# Create roles' and database
-sudo psql -h website-db -U postgres \
--f ${path}/create_roles.sql \
--f ${path}/create_database.sql 
+# Defaults (can be overridden by env vars or flags)
+DB_HOST="${DB_HOST:-localhost}"
+DB_PORT="${DB_PORT:-5432}"
+DB_NAME="${DB_NAME:-matprat}"
+DB_USER="${DB_USER:-nodejs}"
+DB_PASSWORD="${DB_PASSWORD:-nodejs}"
+SQL_PATH="${SQL_PATH:-./sql}"
+WITH_DATA=false
 
-# Insert data into database
-sudo psql -h website-db -U postgres matprat \
--f ${path}/create_all.sql \
--f ${path}/insert_recipes.sql \
--f ${path}/insert_ingredients.sql \
--f ${path}/insert_steps.sql \
--f ${path}/insert_images.sql
+# Parse command line arguments
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -h|--host) DB_HOST="$2"; shift 2 ;;
+    -p|--port) DB_PORT="$2"; shift 2 ;;
+    -d|--database) DB_NAME="$2"; shift 2 ;;
+    -u|--user) DB_USER="$2"; shift 2 ;;
+    -w|--password) DB_PASSWORD="$2"; shift 2 ;;
+    -s|--sql-path) SQL_PATH="$2"; shift 2 ;;
+    --with-data) WITH_DATA=true; shift ;;
+    --help)
+      head -25 "$0" | tail -23
+      exit 0
+      ;;
+    *) echo "Unknown option: $1"; exit 1 ;;
+  esac
+done
+
+export PGPASSWORD="$DB_PASSWORD"
+
+echo "🗄️  Initializing database..."
+echo "   Host: $DB_HOST:$DB_PORT"
+echo "   Database: $DB_NAME"
+echo "   User: $DB_USER"
+echo "   SQL Path: $SQL_PATH"
+
+# Create schema (types, tables, functions)
+echo "📝 Creating schema..."
+psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" \
+  -f "${SQL_PATH}/create_all.sql"
+
+# Create users table
+echo "👤 Creating users table..."
+psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" \
+  -f "${SQL_PATH}/create_users.sql"
+
+# Optionally insert sample data
+if [ "$WITH_DATA" = true ]; then
+  echo "📦 Inserting sample data..."
+  psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" \
+    -f "${SQL_PATH}/insert_recipes.sql" \
+    -f "${SQL_PATH}/insert_categories.sql" \
+    -f "${SQL_PATH}/insert_ingredients.sql" \
+    -f "${SQL_PATH}/insert_steps.sql" \
+    -f "${SQL_PATH}/insert_images.sql"
+fi
+
+echo "✅ Database initialization complete!"

--- a/production/docker-compose.yml
+++ b/production/docker-compose.yml
@@ -30,8 +30,9 @@ services:
     container_name: "matprat-db"
     volumes:
       - matprat-data:/var/lib/postgresql/data
+      - ./sql:/docker-entrypoint-initdb.d:ro
     environment:
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-nodejs}
       POSTGRES_USER: ${DB_USER:-nodejs}
       POSTGRES_DB: ${DB_NAME:-matprat}
       PGDATA: /var/lib/postgresql/data
@@ -66,7 +67,7 @@ services:
     ports:
       - "${PGADMIN_PORT:-5050}:80"
     environment:
-      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_EMAIL:-admin@localhost}
+      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_EMAIL:-admin@local.dev}
       PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_PASSWORD:-admin}
       PGADMIN_LISTEN_PORT: 80
 
@@ -75,7 +76,8 @@ services:
     restart: unless-stopped
     container_name: "matprat-watchtower"
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    user: root
     environment:
       WATCHTOWER_CLEANUP: "true"
       WATCHTOWER_POLL_INTERVAL: 300

--- a/production/docker-compose.yml
+++ b/production/docker-compose.yml
@@ -16,13 +16,20 @@ services:
       DB_PORT: 5432
       SESSION_SECRET: ${SESSION_SECRET:-change-me-in-production}
     ports:
-      - "${WEB_PORT:-3000}:3000"
+      - "${LAN_IP:-127.0.0.1}:${WEB_PORT:-3000}:3000"
+    mem_limit: 256m
+    cpus: 0.5
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
-      interval: 5s
+      interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 5s
+      start_period: 10s
 
   db:
     image: postgres:14-alpine
@@ -36,6 +43,13 @@ services:
       POSTGRES_USER: ${DB_USER:-nodejs}
       POSTGRES_DB: ${DB_NAME:-matprat}
       PGDATA: /var/lib/postgresql/data
+    mem_limit: 256m
+    cpus: 0.5
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   db_backups:
     image: prodrigestivill/postgres-backup-local:14-alpine
@@ -57,6 +71,13 @@ services:
       BACKUP_KEEP_WEEKS: 4
       BACKUP_KEEP_MONTHS: 6
       HEALTHCHECK_PORT: 8000
+    mem_limit: 128m
+    cpus: 0.25
+    logging:
+      driver: json-file
+      options:
+        max-size: "5m"
+        max-file: "2"
 
   pgadmin:
     image: dpage/pgadmin4:latest
@@ -65,24 +86,37 @@ services:
     depends_on:
       - db
     ports:
-      - "${PGADMIN_PORT:-5050}:80"
+      - "${LAN_IP:-127.0.0.1}:${PGADMIN_PORT:-5050}:80"
     environment:
       PGADMIN_DEFAULT_EMAIL: ${PGADMIN_EMAIL:-admin@local.dev}
       PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_PASSWORD:-admin}
       PGADMIN_LISTEN_PORT: 80
+    mem_limit: 256m
+    cpus: 0.25
+    logging:
+      driver: json-file
+      options:
+        max-size: "5m"
+        max-file: "2"
 
   watchtower:
     image: containrrr/watchtower
     restart: unless-stopped
     container_name: "matprat-watchtower"
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-    user: root
+      - ${DOCKER_SOCK:-/var/run/docker.sock}:/var/run/docker.sock
     environment:
       WATCHTOWER_CLEANUP: "true"
       WATCHTOWER_POLL_INTERVAL: 300
       WATCHTOWER_INCLUDE_STOPPED: "false"
     command: matprat-website
+    mem_limit: 64m
+    cpus: 0.1
+    logging:
+      driver: json-file
+      options:
+        max-size: "5m"
+        max-file: "2"
 
 volumes:
   matprat-data:

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -14,5 +14,5 @@ COPY . .
 RUN chown -R node /usr/src/app
 EXPOSE 3000
 
-# Use different commands based on NODE_ENV
-CMD if [ "$NODE_ENV" = "development" ] ; then npm run dev ; else npm start ; fi
+# Use exec to ensure signals reach Node.js for graceful shutdown
+CMD if [ "$NODE_ENV" = "development" ] ; then exec npm run dev ; else exec npm start ; fi

--- a/server/views/partials/nav.ejs
+++ b/server/views/partials/nav.ejs
@@ -5,33 +5,33 @@
     <a class="navbar-brand fw-bold" href="/">
       <i class="bi bi-egg-fried"></i> Marius Foods
     </a>
-    
+
     <!-- Mobile Toggle Button -->
-    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" 
-            aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
+      aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
-    
+
     <!-- Navigation Links -->
     <div class="collapse navbar-collapse" id="navbarNav">
       <ul class="navbar-nav ms-auto">
         <li class="nav-item">
-          <a class="nav-link <%= typeof activePage !== 'undefined' && activePage === 'home' ? 'active' : '' %>" 
-             <%= typeof activePage !== 'undefined' && activePage === 'home' ? 'aria-current="page"' : '' %>
-             href="/">
+          <a class="nav-link <%= typeof activePage !== 'undefined' && activePage === 'home' ? 'active' : '' %>"
+            <%=typeof activePage !=='undefined' && activePage==='home' ? 'aria-current="page"' : '' %>
+            href="/">
             <i class="bi bi-house-door"></i> Home
           </a>
         </li>
         <li class="nav-item">
-          <a class="nav-link <%= typeof activePage !== 'undefined' && activePage === 'recipes' ? 'active' : '' %>" 
-             <%= typeof activePage !== 'undefined' && activePage === 'recipes' ? 'aria-current="page"' : '' %>
-             href="/recipes">
+          <a class="nav-link <%= typeof activePage !== 'undefined' && activePage === 'recipes' ? 'active' : '' %>"
+            <%=typeof activePage !=='undefined' && activePage==='recipes' ? 'aria-current="page"' : '' %>
+            href="/recipes">
             <i class="bi bi-book"></i> Recipes
           </a>
         </li>
-        
+
         <!-- Auth Links -->
-        <% if (typeof session !== 'undefined' && session && session.userId) { %>
+        <% if (typeof session !=='undefined' && session && session.userId) { %>
           <!-- Logged in: Show Admin + Logout -->
           <li class="nav-item">
             <a class="nav-link" href="/admin">
@@ -43,16 +43,15 @@
               <i class="bi bi-box-arrow-right"></i> Logout
             </a>
           </li>
-        <% } else { %>
-          <!-- Not logged in: Show Login -->
-          <li class="nav-item">
-            <a class="nav-link" href="/login">
-              <i class="bi bi-box-arrow-in-right"></i> Login
-            </a>
-          </li>
-        <% } %>
+          <% } else { %>
+            <!-- Not logged in: Show Login -->
+            <li class="nav-item">
+              <a class="nav-link" href="/login">
+                <i class="bi bi-box-arrow-in-right"></i> Login
+              </a>
+            </li>
+            <% } %>
       </ul>
     </div>
   </div>
 </nav>
-


### PR DESCRIPTION
- Add `< /dev/tty` redirection to all read prompts for database credentials, pgAdmin settings, web port, and session secret
- Ensures prompts work correctly when script input is piped or redirected