### PR TITLE
migrate database backups to Docker volume 

### DIFF
--- a/production/docker-compose.yml
+++ b/production/docker-compose.yml
@@ -57,7 +57,7 @@ services:
     container_name: "matprat-db-backup"
     user: postgres:postgres
     volumes:
-      - /var/opt/db_backups:/backups
+      - matprat-backups:/backups
     depends_on:
       - db
     environment:
@@ -110,7 +110,7 @@ services:
       WATCHTOWER_POLL_INTERVAL: 300
       WATCHTOWER_INCLUDE_STOPPED: "false"
     command: matprat-website
-    mem_limit: 64m
+    mem_limit: 128m
     cpus: 0.1
     logging:
       driver: json-file
@@ -120,3 +120,4 @@ services:
 
 volumes:
   matprat-data:
+  matprat-backups:

--- a/production/install.sh
+++ b/production/install.sh
@@ -114,11 +114,6 @@ fi
 # shellcheck disable=SC1091
 source .env
 
-# Create backup directory with correct permissions for postgres user (uid 70 in alpine)
-echo "📁 Creating backup directory..."
-sudo mkdir -p /var/opt/db_backups
-sudo chown -R 70:70 /var/opt/db_backups
-
 # Pull and start containers
 echo ""
 echo "🐳 Pulling Docker images..."


### PR DESCRIPTION
chore: migrate database backups to Docker volume and increase watchtower memory limit

- Replace host path /var/opt/db_backups with named volume matprat-backups
- Remove backup directory creation and permission setup from install.sh
- Increase watchtower memory limit from 64m to 128m
- Add matprat-backups volume definition to docker-compose.yml